### PR TITLE
Update workflows and documentation templates to v0.1

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           exclude-labels: duplicate,question,invalid,wontfix,auto-update
-      - name: Create Pull Request
+      - name: Create Changelog Pull Request
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
           labels: auto-update
           branch: auto-update-changelog
           body: Update CHANGELOG.md with information from latest release
-      - name: Merge Pull Request
+      - name: Merge Changelog Pull Request
         if: env.PULL_REQUEST_NUMBER != null
         uses: juliangruber/merge-pull-request-action@v1
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
         run: sbt ci-docs
         env:
           DOWNLOAD_INFO_FROM_GITHUB: true
-      - name: Create Pull Request
+      - name: Create Documentation Pull Request
         uses: peter-evans/create-pull-request@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
           labels: auto-update,documentation
           branch: auto-update-docs
           body: Update documentation and other files with latest changes.
-      - name: Merge Pull Request
+      - name: Merge Documentation Pull Request
         if: env.PULL_REQUEST_NUMBER != null
         uses: juliangruber/merge-pull-request-action@v1
         with:


### PR DESCRIPTION
- First version of the documentation files, including `AUTHORS.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and `NOTICE.md`
- First version of the workflow files, including workflows for updating changelog and docs, for running the release task and executing the ci.

In order for running, `ci`, `docs` and `release` workflows the following aliases (with the same, or different commands) should be created in `build.sbt`:

```scala
addCommandAlias("ci-test", "fix --check; mdoc; test; publishLocal; all scripted")
addCommandAlias("ci-docs", "mdoc; headerCreateAll")

//Not needed if using `sbt-ci-release`
addCommandAlias("ci-release", "publish")
```