### PR TITLE
Add `per_page` query param to contributors and collaborators URLs

### DIFF
--- a/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/github/Repository.scala
+++ b/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/github/Repository.scala
@@ -31,6 +31,7 @@ import com.alejandrohdezma.sbt.github.json.Decoder
 import com.alejandrohdezma.sbt.github.syntax.json._
 import com.alejandrohdezma.sbt.github.syntax.list._
 import com.alejandrohdezma.sbt.github.syntax.scalatry._
+import com.alejandrohdezma.sbt.github.syntax.url._
 
 /** Represents a repository in Github */
 final case class Repository(
@@ -61,7 +62,7 @@ final case class Repository(
     logger.info(s"Retrieving `$name` contributors from Github API")
 
     client
-      .get[List[Contributor]](contributorsUrl)
+      .get[List[Contributor]](contributorsUrl.withQueryParam("per_page", "100"))
       .map(_.sortBy(-_.contributions))
       .map(_.filterNot(contributor => excluded.exists(contributor.login.matches)))
       .map(Contributors)
@@ -79,7 +80,7 @@ final case class Repository(
     logger.info(s"Retrieving `$name` collaborators from Github API")
 
     client
-      .get[List[Collaborator]](collaboratorsUrl)
+      .get[List[Collaborator]](collaboratorsUrl.withQueryParam("per_page", "100"))
       .map(_.filter(m => allowed.contains(m.login)))
       .flatMap(_.traverse { collaborator =>
         logger.info(s"Retrieving `${collaborator.login}` information from Github API")

--- a/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/syntax/url.scala
+++ b/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/syntax/url.scala
@@ -1,0 +1,33 @@
+package com.alejandrohdezma.sbt.github.syntax
+
+import sbt.URI
+import sbt.URL
+
+object url {
+
+  implicit class UrlOps(private val url: URL) extends AnyVal {
+
+    /**
+     * Adds a query param with the given `key`/`value` pair to
+     * this `URL` ad returns it.
+     */
+    @SuppressWarnings(Array("scalafix:Disable.toURI"))
+    def withQueryParam(key: String, value: String): URL = {
+      val uri = url.toURI
+
+      val query = Option(uri.getQuery)
+        .map(_ + s"&$key=$value")
+        .getOrElse(s"$key=$value")
+
+      new URI(
+        uri.getScheme,
+        uri.getAuthority,
+        uri.getPath,
+        query,
+        uri.getFragment
+      ).toURL
+    }
+
+  }
+
+}

--- a/sbt-github/src/test/scala/com/alejandrohdezma/sbt/github/syntax/UrlSyntaxSpec.scala
+++ b/sbt-github/src/test/scala/com/alejandrohdezma/sbt/github/syntax/UrlSyntaxSpec.scala
@@ -1,0 +1,34 @@
+package com.alejandrohdezma.sbt.github.syntax
+
+import sbt.URL
+
+import com.alejandrohdezma.sbt.github.syntax.url._
+import org.specs2.mutable.Specification
+
+class UrlSyntaxSpec extends Specification {
+
+  "Uri#withQueryParam" should {
+
+    "add query param to Uri without query" >> {
+      val uri = new URL("https://example.com")
+
+      val result = uri.withQueryParam("miau", "42")
+
+      val expected = new URL("https://example.com?miau=42")
+
+      result must be equalTo expected
+    }
+
+    "add query param to URL with query" >> {
+      val uri = new URL("https://example.com?page=2")
+
+      val result = uri.withQueryParam("miau", "42")
+
+      val expected = new URL("https://example.com?page=2&miau=42")
+
+      result must be equalTo expected
+    }
+
+  }
+
+}


### PR DESCRIPTION
# Why?

This way we can avoid doing too many calls to the Github API, which will result in more requests per hour.

# Reference

- [Github API pagination](https://developer.github.com/v3/#pagination)