### PR TITLE
Deprecate `githubToken` in favour of `githubAuthToken`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 ThisBuild / scalaVersion := "2.12.11"
 ThisBuild / organization := "com.alejandrohdezma"
 
-Global / onChangedBuildSource := ReloadOnSourceChanges
-
 addCommandAlias("ci-test", "fix --check; mdoc; publishLocal; scripted; testCovered")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
 addCommandAlias("ci-publish", "github; ci-release")

--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,7 @@ skip in publish := true
 val `sbt-mdoc`   = "org.scalameta"     % "sbt-mdoc"   % "[2.0,)"   % Provided // scala-steward:off
 val `sbt-header` = "de.heikoseeberger" % "sbt-header" % "[5.6.0,)" % Provided // scala-steward:off
 
-lazy val docs = project
-  .in(file("sbt-github-docs"))
+lazy val documentation = project
   .enablePlugins(MdocPlugin)
   .settings(skip in publish := true)
   .settings(mdocOut := file("."))

--- a/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
+++ b/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
@@ -156,7 +156,7 @@ object SbtGithubPlugin extends AutoPlugin {
       if (githubEnabled.value) Def.setting {
         implicit val log: Logger                  = sLog.value
         implicit val entryPoint: GithubEntryPoint = GithubEntryPoint(githubApiEntryPoint.value)
-        implicit val auth: Authentication         = githubToken.value
+        implicit val auth: Authentication         = githubAuthToken.value.getOrElse(githubToken.value)
 
         Some(Repository.get(info.value._1, info.value._2).get)
       }
@@ -164,7 +164,7 @@ object SbtGithubPlugin extends AutoPlugin {
     }.value,
     organizationMetadata := {
       implicit val log: Logger          = sLog.value
-      implicit val auth: Authentication = githubToken.value
+      implicit val auth: Authentication = githubAuthToken.value.getOrElse(githubToken.value)
       repository.value
         .flatMap(_.organization)
         .orElse {
@@ -176,14 +176,14 @@ object SbtGithubPlugin extends AutoPlugin {
     },
     contributors := {
       implicit val log: Logger          = sLog.value
-      implicit val auth: Authentication = githubToken.value
+      implicit val auth: Authentication = githubAuthToken.value.getOrElse(githubToken.value)
       repository.value.fold(Contributors(Nil)) {
         _.contributors(excludedContributors.value).get
       }
     },
     collaborators := {
       implicit val log: Logger          = sLog.value
-      implicit val auth: Authentication = githubToken.value
+      implicit val auth: Authentication = githubAuthToken.value.getOrElse(githubToken.value)
       repository.value.fold(Collaborators(Nil)) {
         _.collaborators(contributors.value.list.map(_.login)).get
           .include(

--- a/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
+++ b/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
@@ -113,7 +113,13 @@ object SbtGithubPlugin extends AutoPlugin {
       "Organization email"
     }
 
+    @deprecated("Use githubAuthToken instead", since = "0.8.1")
     val githubToken = settingKey[Token] {
+      "The Github Token used for authenticating into Github API. Defaults to GITHUB_TOKEN environment variable. " +
+        "Deprecated, use `githubAuthToken` instead."
+    }
+
+    val githubAuthToken = settingKey[Option[AuthToken]] {
       "The Github Token used for authenticating into Github API. Defaults to GITHUB_TOKEN environment variable."
     }
 
@@ -145,6 +151,7 @@ object SbtGithubPlugin extends AutoPlugin {
         "You need to add an environment variable named GITHUB_TOKEN with a Github personal access token."
       })
     },
+    githubAuthToken := sys.env.get("GITHUB_TOKEN").map(AuthToken),
     repository := Def.settingDyn {
       if (githubEnabled.value) Def.setting {
         implicit val log: Logger                  = sLog.value

--- a/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
+++ b/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
@@ -54,8 +54,14 @@ object SbtGithubPlugin extends AutoPlugin {
     type Collaborator = github.Collaborator
     val Collaborator = github.Collaborator
 
+    @deprecated("Use AuthToken instead", since = "0.8.1")
     type Token = http.Authentication.Token
+
+    @deprecated("Use AuthToken instead", since = "0.8.1")
     val Token = http.Authentication.Token
+
+    type AuthToken = http.Authentication.AuthToken
+    val AuthToken = http.Authentication.AuthToken
 
     val githubApiEntryPoint = settingKey[URL] {
       "Entry point for the github API, defaults to `https://api.github.com`"

--- a/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/http/Authentication.scala
+++ b/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/http/Authentication.scala
@@ -24,6 +24,13 @@ trait Authentication {
 
 object Authentication {
 
+  final case class AuthToken(value: String) extends Authentication {
+
+    override def header: String = s"token $value"
+
+  }
+
+  @deprecated("Use AuthToken instead", since = "0.8.1")
   final class Token(value: => String) extends Authentication {
 
     override def header: String = s"token $value"


### PR DESCRIPTION
The `githubToken` setting has been deprecated in favour of `githubAuthToken`.

This will probably mean nothing for most of the users, if the default configuration is being used (using a `GITHUB_TOKEN` environment variable), since the same default configuration is being used for `githubAuthToken` as was used for `githubToken`.

The only noticeable change is the type. `githubToken` had type `Token` while `githubAuthToken` has type `Option[AuthToken]` which allows for directly recover environment variable...

```sbt
githubAuthToken := sys.env("GITHUB_TOKEN").map(AuthToken)
```

...while also provides a better integration with other projects, such as [`sbt-microsites`](https://github.com/47degrees/sbt-microsites)