### PR TITLE
Support `scala-steward` `scmInfo`

### DIFF
--- a/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
+++ b/sbt-github/src/main/scala/com/alejandrohdezma/sbt/github/SbtGithubPlugin.scala
@@ -134,12 +134,14 @@ object SbtGithubPlugin extends AutoPlugin {
   private[github] val info = Def.setting {
     val identifier = """([^\/]+)"""
 
-    val Connection = s"scm:git:https://github.com/$identifier/$identifier.git".r
+    val Connection      = s"scm:git:https://github.com/$identifier/$identifier.git".r
+    val ConnectionLogin = s"scm:git:https://$identifier@github.com/$identifier/$identifier.git".r
 
     scmInfo.value.map(_.connection) match {
-      case Some(Connection(owner, repo)) => (owner, repo)
-      case None                          => sys.error("`scmInfo` is mandatory for this plugin to work")
-      case Some(s)                       => sys.error(s"Invalid `scmInfo` connection value: $s")
+      case Some(Connection(owner, repo))         => (owner, repo)
+      case Some(ConnectionLogin(_, owner, repo)) => (owner, repo)
+      case None                                  => sys.error("`scmInfo` is mandatory for this plugin to work")
+      case Some(s)                               => sys.error(s"Invalid `scmInfo` connection value: $s")
     }
   }
 

--- a/sbt-github/src/sbt-test/sbt-github/override-organization/build.sbt
+++ b/sbt-github/src/sbt-test/sbt-github/override-organization/build.sbt
@@ -1,5 +1,5 @@
 ThisBuild / scmInfo := Some(
-  ScmInfo(url("http://example.com"), "scm:git:https://github.com/alejandrohdezma/sbt-github.git")
+  ScmInfo(url("http://example.com"), "scm:git:https://alejandrohdezma@github.com/alejandrohdezma/sbt-github.git")
 )
 ThisBuild / githubEnabled      := true
 ThisBuild / githubOrganization := "different-org"


### PR DESCRIPTION
`scala-steward` clones repos in a way that the created `scmInfo` will be something like...

```
scm:git:https://alejandrohdezma@github.com/alejandrohdezma/sbt-github.git
```

...which was provoking a failure on initialization such as:

```
[error] Invalid `scmInfo` connection value: scm:git:https://alejandrohdezma@github.com/alejandrohdezma/sbt-github.git
``` 